### PR TITLE
Make it possible to get a stream from the image properties.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "through2": "^2.0.0"
   },
   "devDependencies": {
-    "mocha": "*"
+    "mocha": "*",
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0"
   },
   "license": "MIT"
 }

--- a/test.js
+++ b/test.js
@@ -46,3 +46,23 @@ it('should not move un-url-like property to separate CSS', function (cb) {
   stream.write(generateFile('a {\n\tbackground: #ddd; color: #ddd;\n}\na {\n\tcolor: #fff;\n}'));
   stream.end();
 });
+
+it('should be possible to get a stream from the image properties', function (cb) {
+  var stream = cssBackgroundRemove({ 
+    writeImagesFile: false
+  });
+  
+  stream.images(function (imagesStream) {
+    imagesStream.on('data', function (file) {
+        assert(file.contents.toString(), 'div {\n\tbackground-image: url(image.png);\n}');
+    })
+  });
+
+  stream.on('data', function (file) {
+    assert(file.contents.toString(), 'a {\n\tbackground: #ddd; color: #ddd;\n}\na {\n\tcolor: #fff;\n}');
+  });
+
+  stream.on('end', cb);
+  stream.write(generateFile('a {\n\tbackground: #ddd; color: #ddd;\n}\na {\n\tcolor: #fff;\n}\ndiv {\n\tbackground-image: url(image.jpg);\n}'));
+  stream.end();
+});


### PR DESCRIPTION
Hey Hans!
I was using your plugin, but felt the need of having the images CSS streamed, so I could use other plugins before saving the final CSS.
This implementation makes it possible by returning an extended object which contains the method images. This method accepts a callback, and invoke it passing the images CSS stream as a parameter.
I added also an option writeImagesFile, which when set to false, prevents the file to be written.
